### PR TITLE
增加 go-cqhttp QQ机器人推送

### DIFF
--- a/.github/workflows/wzxy_healthcheck.yml
+++ b/.github/workflows/wzxy_healthcheck.yml
@@ -35,6 +35,9 @@ jobs:
         DD_BOT_ACCESS_TOKEN: ${{secrets.DD_BOT_ACCESS_TOKEN}}
         DD_BOT_SECRET: ${{secrets.DD_BOT_SECRET}}
         SCT_KEY: ${{secrets.SCT_KEY}}
+        GOBOT_URL: ${{secrets.GOBOT_URL}}
+        GOBOT_QQ: ${{secrets.GOBOT_QQ}}
+        GOBOT_TOKEN: ${{secrets.GOBOT_TOKEN}}
         BARK_TOKEN: ${{secrets.BARK_TOKEN}}
         PUSHPLUS_TOKEN: ${{secrets.PUSHPLUS_TOKEN}}
         MIAO_CODE: ${{secrets.MIAO_CODE}}

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@
   
   > 如需配置钉钉机器人，上述的 `DD_BOT_ACCESS_TOKEN` 和 `DD_BOT_SECRET` 两条 Secrect 都需创建。
 
+  - `GOBOT_URL`（可选）：go-cqhttp 推送到个人QQ: http://127.0.0.1/send_private_msg  群：http://127.0.0.1/send_group_msg 
+
+  - `GOBOT_TOKEN`（可选）：填写在go-cqhttp文件设置的访问密钥`access-token`，可不填
+ 
+  - `GOBOT_QQ`（可选）：go-cqhttp如果GOBOT_URL设置 /send_private_msg 则需要填入 user_id=个人QQ，相反如果是 /send_group_msg 则需要填入 group_id=QQ群 
+  
+  > 如需配置go-cqhttp，上述的 `GOBOT_URL` 和 `GOBOT_QQ` 为必填项，`GOBOT_TOKEN`可为空。
+  > go-cqhttp相关API https://docs.go-cqhttp.org/api
+
   > **推送通知的补充说明**
   >
   > 目前支持四种推送方式（PushPlus、Serverchan-Turbo、Bark、钉钉机器人）：

--- a/wzxy-healthcheck.py
+++ b/wzxy-healthcheck.py
@@ -172,6 +172,17 @@ class WoZaiXiaoYuanPuncher:
             }
             requests.post(url, data=msg)
             print("消息经pushplus推送成功")
+        if os.environ.get('GOBOT_URL'):
+            # go_cqhttp 推送
+            GOBOT_URL = os.environ["GOBOT_URL"]
+            GOBOT_TOKEN = os.environ["GOBOT_TOKEN"]
+            GOBOT_QQ = os.environ["GOBOT_QQ"]
+            url = f'{GOBOT_URL}?access_token={GOBOT_TOKEN}&{GOBOT_QQ}&message=⏰ 我在校园打卡结果通知\n---------\n\n打卡项目：健康打卡\n\n打卡情况：{notifyResult}\n\n打卡时间: {notifyTime}'
+            response = requests.get(url).json()
+            if response["status"] == "ok":
+                print("消息经 go-cqhttp 推送成功！")
+            else:
+                print("消息经 go-cqhttp 推送失败！")
         if os.environ.get('DD_BOT_ACCESS_TOKEN'):
             # 钉钉推送
             DD_BOT_ACCESS_TOKEN = os.environ["DD_BOT_ACCESS_TOKEN"]


### PR DESCRIPTION
新增3个环境变量，`GOBOT_URL` 和 `GOBOT_QQ` 为必填项，`GOBOT_TOKEN`可为空。
go-cqhttp 服务端需自行配置，go-cqhttp 相关 API https://docs.go-cqhttp.org/api

![](https://ypy.baifan97.cn/typecho/uploads/pic/QQ图片20211114151751.jpg)